### PR TITLE
Add merge-strategies input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 - `path`: The path to the file within the repository.
 - `user-email`: The email of the user that commits the version file.
 - `user-name`: The name of the user that commits the version file.
+- `merge-strategy`: How to reconcile divergent branches when pulling.
+  - `merge`: Tries to merge (default)
+  - `rebase`: Tries to rebase
+  - `fast-forward`: Only allows for fast forwards
 
 For information on how GitHub actions tokens work, read more [here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token#about-the-github_token-secret).
 
@@ -52,6 +56,7 @@ jobs:
           path: ./Source/version.json
           user-email: build@dolittle.com
           user-name: dolittle-build
+          merge-strategy: merge
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: The name of the user that commits the version file
     required: false
     default: 'dolittle-build'
+  merge-strategy:
+      description: How to reconcile divergent branches. Can be either 'merge'(default), 'rebase' or 'fast-forward'
+      required: false
+      default: 'merge'
  
 runs:
   using: 'node12'


### PR DESCRIPTION
## Summary

Adds a `merge-strategies` input that defines how `git pull` should deal with diverging branches. Can be either `merge` (default), `rebase` or `fast-forward`.
